### PR TITLE
Threshold management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Simple discord bot for basic "moderation" functions via reactions
 ### Commands
 
 * !version - Simple test to make sure the bot is working
+* !threshold - Command to control reaction thresholds in a given server. Run !threshold help for more info.

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -5,11 +5,13 @@ let { prefix } = require('../config.json');
 
 module.exports = {
 	name: 'threshold',
-	description: `Manages the server reaction thresholds for punishing users. \`${prefix}threshold help\` for more info.`,
+	description: `Manages the server reaction thresholds for punishing users. \`${prefix}${module.exports.name} help\` for more info.`,
 	permission: 1,
 	execute(msg, args) {
 		// Convert all arguments to lowercase
 		args.forEach(function(arg, index) { args[index] = arg.toLowerCase() });
+		const command = prefix + module.exports.name;
+		const properUsage = `Proper usage: \`${command} add <count> <time>\``;
 
 		switch(args[0]) {
 			case 'add':
@@ -17,48 +19,82 @@ module.exports = {
 				if (args.length == 3) {
 					let count = Number.parseInt(args[1]);
 					let time = Number.parseInt(args[2]);
+
+					if (isNaN(count) || isNaN(time)) {
+						msg.reply(`Invalid arguments given. ${properUsage}.`);
+						return;
+					}
+
 					if (count <= 0) {
 						msg.reply('Invalid reaction amount. Please use a number bigger than 0.');
 					} else if (time <= 0) {
 						msg.reply('Invalid amount of minutes. Please use a number bigger than 0.');
 					} else {
 						dbHelper.setThreshold(msg.guild.id, new dbHelper.Threshold(count, time))
-							.then(result => msg.channel.send(`Successfully ${result == 0 ? 'set' : 'updated'} the punishment for ${count} reaction${count > 1 ? 's' : ''} to ${time} minute${time > 1 ? 's' : ''}`))
-							.catch(() => {});
+							.then(result => msg.channel.send(`Successfully ${result == 0 ? 'added' : 'updated'} the punishment for ${count} reaction${count > 1 ? 's' : ''} to ${time} minute${time > 1 ? 's' : ''}`))
+							.catch(err => { throw err });
 					}
+				} else {
+					msg.reply(`Invalid number of arguments. ${properUsage}.`);
 				}
 				break;
 			case 'del':
 			case 'delete':
 			case 'remove':
 			case 'rem':
-				msg.channel.send('Not yet implemented. Try again later :slight_smile:');
+				let properUsage = `Proper usage: \`${command} del <count>\``;
+				if (args.length == 2) {
+					let count = Number.parseInt(args[1]);
+					if (isNaN(count)) {
+						msg.reply(`Invalid arguments given. ${properUsage}.`);
+						return;
+					}
+
+					if (count <= 0) {
+						msg.reply('Invalid reaction amount. Please use a number bigger than 0.');
+					} else {
+						dbHelper.removeThreshold(msg.guild.id, count)
+							.then(result => {
+								if (result == 0) {
+									msg.channel.send(
+										`Successfully removed reaction threshold for ${count} reaction${count > 1 ? 's' : ''}`);
+								} else if (result == 1) {
+									msg.channel.send('No thresholds exist for this server. Please set some before trying to remove them.');
+								} else {
+									msg.channel.send('Well there wasn\'t an error but this situation wasn\'t covered sooooooo');
+								}
+							})
+							.catch(err => { throw err });
+					}
+				} else {
+					msg.reply(`Invalid number of arguments. ${properUsage}.`);
+				}
 				break;
 			case 'web':
 			case 'site':
 			case 'website':
-				msg.channel.send('Also not implemented. Please try again later. :smile:');
+				msg.channel.send('Not yet implemented. Try again later :slight_smile:');
 				break;
 			case 'help':
 				msg.channel.send(
-`\`${prefix}threshold help\`
+`\`${command} help\`
 Shows this command.
 
-\`${prefix}threshold <set/add> <count> <time>\`
+\`${command} <set/add> <count> <time>\`
 Adds a new reaction threshold of 'count' reactions for 'time' minutes.
 \`\`\`
-usage: ${prefix}threshold set 3 15
+usage: ${command} set 3 15
   Creates a threshold for 3 reactions = 15 minute punishment. If a threshold for 3 reactions already exists, it is replaced with 15 minutes.\`\`\`
-\`${prefix}threshold <del/delete/rem/remove> <count>\`
+\`${command} <del/delete/rem/remove> <count>\`
 Removes the reaction threshold for count reactions.
 \`\`\`
-usage: ${prefix}threshold del 3
+usage: ${command} del 3
   Removes whatever threshold for 3 reactions is, if one exists.\`\`\`
-\`${prefix}threshold <site/web/website>\`
+\`${command} <site/web/website>\`
 Sends the URL for manging thresholds from a web interface.`);
 				break;
 			default:
-				msg.channel.send(`Invalid argument. Please try \`${prefix}threshold help\` for help.`)
+				msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`)
 		}
 	}
 };

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -8,22 +8,22 @@ module.exports = {
 	description: `Manages the server reaction thresholds for punishing users. \`${prefix}threshold help\` for more info.`,
 	permission: 1,
 	execute(msg, args) {
-        // Convert all arguments to lowercase
-        args.forEach(function(arg, index) { args[index] = arg.toLowerCase() });
+		// Convert all arguments to lowercase
+		args.forEach(function(arg, index) { args[index] = arg.toLowerCase() });
 
-        switch(args[0]) {
-            case 'add':
-            case 'set':
-                msg.channel.send('Add / set');
-                break;
-            case 'del':
-            case 'delete':
-            case 'remove':
-            case 'rem':
-                msg.channel.send('Delete / remove');
-                break;
-            case 'help':
-                msg.channel.send(
+		switch(args[0]) {
+			case 'add':
+			case 'set':
+				msg.channel.send('Add / set');
+				break;
+			case 'del':
+			case 'delete':
+			case 'remove':
+			case 'rem':
+				msg.channel.send('Delete / remove');
+				break;
+			case 'help':
+				msg.channel.send(
 `\`${prefix}threshold help\`
 Shows this command.
 
@@ -39,9 +39,9 @@ usage: ${prefix}threshold del 3
   Removes whatever threshold for 3 reactions is, if one exists.\`\`\`
 \`${prefix}threshold <site/web/website>\`
 Sends the URL for manging thresholds from a web interface.`);
-                break;
-            default:
-                msg.channel.send(`Invalid argument. Please try \`${prefix}threshold help\` for help.`)
-        }
+				break;
+			default:
+				msg.channel.send(`Invalid argument. Please try \`${prefix}threshold help\` for help.`)
+		}
 	}
 };

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -34,6 +34,11 @@ module.exports = {
 			case 'rem':
 				msg.channel.send('Not yet implemented. Try again later :slight_smile:');
 				break;
+			case 'web':
+			case 'site':
+			case 'website':
+				msg.channel.send('Also not implemented. Please try again later. :smile:');
+				break;
 			case 'help':
 				msg.channel.send(
 `\`${prefix}threshold help\`

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -14,6 +14,19 @@ module.exports = {
 		switch(args[0]) {
 			case 'add':
 			case 'set':
+				if (args.length == 3) {
+					let count = Number.parseInt(args[1]);
+					let time = Number.parseInt(args[2]);
+					if (count <= 0) {
+						msg.reply('Invalid reaction amount. Please use a number bigger than 0.');
+					} else if (time <= 0) {
+						msg.reply('Invalid amount of minutes. Please use a number bigger than 0.');
+					} else {
+						dbHelper.setThreshold(msg.guild.id, new dbHelper.Threshold(count, time))
+							.then(result => msg.channel.send(`Successfully ${result == 0 ? 'set' : 'updated'} the punishment for ${count} reaction${count > 1 ? 's' : ''} to ${time} minute${time > 1 ? 's' : ''}`))
+							.catch(() => {});
+					}
+				}
 				msg.channel.send('Add / set');
 				break;
 			case 'del':

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -38,6 +38,12 @@ module.exports = {
 					msg.reply(`Invalid number of arguments. ${properUsage}.`);
 				}
 				break;
+			case 'list':
+			case 'view':
+				dbHelper.viewThresholds(msg.guild.id)
+					.then(reply => msg.channel.send(reply))
+					.catch(err => { throw err; });
+				break;
 			case 'del':
 			case 'delete':
 			case 'remove':
@@ -80,7 +86,10 @@ module.exports = {
 `\`${command} help\`
 Shows this command.
 
-\`${command} <set/add> <count> <time>\`
+\`${command} <list/view>
+Shows all thresholds for a server, if any exist.
+
+\`${command} <add/set> <count> <time>\`
 Adds a new reaction threshold of 'count' reactions for 'time' minutes.
 \`\`\`
 usage: ${command} set 3 15

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -27,13 +27,12 @@ module.exports = {
 							.catch(() => {});
 					}
 				}
-				msg.channel.send('Add / set');
 				break;
 			case 'del':
 			case 'delete':
 			case 'remove':
 			case 'rem':
-				msg.channel.send('Delete / remove');
+				msg.channel.send('Not yet implemented. Try again later :slight_smile:');
 				break;
 			case 'help':
 				msg.channel.send(

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -1,0 +1,47 @@
+// Helper module for anything database-related
+const dbHelper = require('../lib/database-helper');
+
+let { prefix } = require('../config.json');
+
+module.exports = {
+	name: 'threshold',
+	description: `Manages the server reaction thresholds for punishing users. \`${prefix}threshold help\` for more info.`,
+	permission: 1,
+	execute(msg, args) {
+        // Convert all arguments to lowercase
+        args.forEach(function(arg, index) { args[index] = arg.toLowerCase() });
+
+        switch(args[0]) {
+            case 'add':
+            case 'set':
+                msg.channel.send('Add / set');
+                break;
+            case 'del':
+            case 'delete':
+            case 'remove':
+            case 'rem':
+                msg.channel.send('Delete / remove');
+                break;
+            case 'help':
+                msg.channel.send(
+`\`${prefix}threshold help\`
+Shows this command.
+
+\`${prefix}threshold <set/add> <count> <time>\`
+Adds a new reaction threshold of 'count' reactions for 'time' minutes.
+\`\`\`
+usage: ${prefix}threshold set 3 15
+  Creates a threshold for 3 reactions = 15 minute punishment. If a threshold for 3 reactions already exists, it is replaced with 15 minutes.\`\`\`
+\`${prefix}threshold <del/delete/rem/remove> <count>\`
+Removes the reaction threshold for count reactions.
+\`\`\`
+usage: ${prefix}threshold del 3
+  Removes whatever threshold for 3 reactions is, if one exists.\`\`\`
+\`${prefix}threshold <site/web/website>\`
+Sends the URL for manging thresholds from a web interface.`);
+                break;
+            default:
+                msg.channel.send(`Invalid argument. Please try \`${prefix}threshold help\` for help.`)
+        }
+	}
+};

--- a/commands/version.js
+++ b/commands/version.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	name: 'version',
-	description: 'Command to get bot version.',
+	description: 'Makes bot say what version it\'s running.',
 	permission: 0,
 	execute(msg) {
 		let package = JSON.parse(require('fs').readFileSync('package.json')).version

--- a/lib/bot-app.js
+++ b/lib/bot-app.js
@@ -4,10 +4,9 @@ require('dotenv').config()
 const fs = require('fs');
 const Discord = require('discord.js');
 
-// Helper module to move all database-based code in a separate file
-let dbHelper = require('./database-helper');
+// Helper module for anything database-related
+const dbHelper = require('./database-helper');
 
-// Config stuff
 let { interval, prefix } = require('../config.json');
 
 // Create discord.js objects
@@ -46,7 +45,7 @@ client.on('message', msg => {
 		var cmds = client.commands.values();
 		var bot_reply = "\n";
 		for (var command of cmds) {
-			bot_reply += "`" + prefix + command.name + "` - " + command.description + "\n";
+			bot_reply += "`" + prefix + command.name + "`\n" + command.description + "\n\n";
 		}
 		msg.channel.send(bot_reply);
 		return;

--- a/lib/bot-app.js
+++ b/lib/bot-app.js
@@ -86,7 +86,7 @@ client.on('messageReactionAdd', (reaction, user) => {
 				msg.reply('There was an error trying to run this command. Please repeatedly spam the mods until they notice it. Thank you.');
 				msg.channel.send(`\`\`\`\n${err}\`\`\``);
 			});
-    }
+	}
 });
 
 // Checks every `interval` seconds to see if anyone needs freed

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -6,10 +6,10 @@ const connectionString = process.env.JAWSDB_MARIA_URL;
 const sqlRegex = /mysql:\/\/(\w+):(\w+)@(.*):(\d+)\/(\w+)/; // connection string format: mysql://<user>:<pass>@<domain.tld>:<port>/<default-schema>
 const result = sqlRegex.exec(connectionString);
 const pool = mariadb.createPool({
-    user: result[1], password: result[2],
-    host: result[3], port: Number.parseInt(result[4]), 
-    database: result[5],
-    connectionLimit: 5
+	user: result[1], password: result[2],
+	host: result[3], port: Number.parseInt(result[4]), 
+	database: result[5],
+	connectionLimit: 5
 });
 
 /**
@@ -17,232 +17,232 @@ const pool = mariadb.createPool({
  * some number of minutes (`Time`) as a punishment.
  */
 class Threshold {
-    /**
-     * @param {Int} count The amount of reactions required
-     * @param {Int} time The amount of minutes to be punished for the amount of reactions
-     */
-    constructor(count=0, time=0) {
-        this.Count = count;
-        this.Time = time;
-    }
+	/**
+	 * @param {Int} count The amount of reactions required
+	 * @param {Int} time The amount of minutes to be punished for the amount of reactions
+	 */
+	constructor(count=0, time=0) {
+		this.Count = count;
+		this.Time = time;
+	}
 }
 
 const helper = {
-    /**
-     * Does all first-time startup code relating to the database. As of now,
-     * it just frees everyone that was being punished.
-     * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
-     * @returns {Promise} - reject message contains error, resolve is empty
-     */
-    init: function(client) {
-        return new Promise((resolve, reject) => {
-            pool.getConnection()
-                .then(conn => {
-                    conn.query('SELECT UserId, GuildId FROM Horny')
-                        // bot can't manage messages sent before it started, so only choice is to free people
-                        .then(rows => {
-                            if (rows.length > 0) {
-                                rows.forEach(function(row) {
-                                    let guild = client.guilds.cache.get(row.GuildId);
-                                    if (guild) {
-                                        guild.members.fetch({user: row.UserId, force: true})
-                                            .then(member => {
-                                                helper.getPunishRole(row.GuildId)
-                                                    .then(roleId => member.roles.remove(roleId))
-                                                    .catch(err => { console.error(`[INIT1] ${err}`); reject(err) })
-                                            })
-                                            .catch(err => { console.error(`[INIT2] ${err}`); reject(err) });
-                                    }
-                                });
-                            }
-                        })
-                        .then(_ => conn.query('DELETE FROM Horny WHERE Id > 0'))
-                        .then(_ => conn.release())
-                        .catch(err => {
-                            console.error(`[INIT3] ${err}`);
-                            conn.release();
-                            reject(err);
-                        });
-                })
-                .then(resolve)
-                .catch(err => { console.error(`[INIT4] ${err}`); reject(err); });
-        });
-    },
+	/**
+	 * Does all first-time startup code relating to the database. As of now,
+	 * it just frees everyone that was being punished.
+	 * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
+	 * @returns {Promise} - reject message contains error, resolve is empty
+	 */
+	init: function(client) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query('SELECT UserId, GuildId FROM Horny')
+						// bot can't manage messages sent before it started, so only choice is to free people
+						.then(rows => {
+							if (rows.length > 0) {
+								rows.forEach(function(row) {
+									let guild = client.guilds.cache.get(row.GuildId);
+									if (guild) {
+										guild.members.fetch({user: row.UserId, force: true})
+											.then(member => {
+												helper.getPunishRole(row.GuildId)
+													.then(roleId => member.roles.remove(roleId))
+													.catch(err => { console.error(`[INIT1] ${err}`); reject(err) })
+											})
+											.catch(err => { console.error(`[INIT2] ${err}`); reject(err) });
+									}
+								});
+							}
+						})
+						.then(_ => conn.query('DELETE FROM Horny WHERE Id > 0'))
+						.then(_ => conn.release())
+						.catch(err => {
+							console.error(`[INIT3] ${err}`);
+							conn.release();
+							reject(err);
+						});
+				})
+				.then(resolve)
+				.catch(err => { console.error(`[INIT4] ${err}`); reject(err); });
+		});
+	},
 
-    /**
-     * Gets all the saved thresholds for reactions from the database. This is how
-     * x reactions = y minutes of punishment is determined.
-     * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
-     * @returns {Promise} - resolve contains array of {Threshold}s organized from smallest `Count` to `Largest`, reject contains error
-     * @see {Threshold}
-     */
-    getThresholds: function(serverId) {
-        return new Promise((resolve, reject) => {
-            pool.getConnection()
-                .then(conn => {
-                    conn.query("SELECT Value FROM Config WHERE Property = 'ReactionThreshold' AND Server = ?", [serverId])
-                        .then(rows => {
-                            // Filter out the additional data given to us from mariadb
-                            let filteredRows = [];
+	/**
+	 * Gets all the saved thresholds for reactions from the database. This is how
+	 * x reactions = y minutes of punishment is determined.
+	 * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
+	 * @returns {Promise} - resolve contains array of {Threshold}s organized from smallest `Count` to `Largest`, reject contains error
+	 * @see {Threshold}
+	 */
+	getThresholds: function(serverId) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query("SELECT Value FROM Config WHERE Property = 'ReactionThreshold' AND Server = ?", [serverId])
+						.then(rows => {
+							// Filter out the additional data given to us from mariadb
+							let filteredRows = [];
 
-                            // Threshold format stored in database as `x:y` where x (int) = number of reactions needed,
-                            // y (int) = number of minutes to punish for `x` total (or more if no value in database higher than x) reactions
-                            const regex = /(\d+):(\d+)/;
-                            for (let i = 0; i < rows.length; i++) {
-                                let result = regex.exec(rows[i].Value);
-                                filteredRows.push(new Threshold(Number.parseInt(result[1]), Number.parseInt(result[2])));
-                            }
+							// Threshold format stored in database as `x:y` where x (int) = number of reactions needed,
+							// y (int) = number of minutes to punish for `x` total (or more if no value in database higher than x) reactions
+							const regex = /(\d+):(\d+)/;
+							for (let i = 0; i < rows.length; i++) {
+								let result = regex.exec(rows[i].Value);
+								filteredRows.push(new Threshold(Number.parseInt(result[1]), Number.parseInt(result[2])));
+							}
 
-                            // Sort by number of reactions needed
-                            filteredRows.sort(function(x, y) {
-                                if (x.Count < y.Count)
-                                    return -1;
-                                else if (x.Count > y.Count)
-                                    return 1;
-                                return 0;
-                            });
-                            resolve(filteredRows);
-                        })
-                        .then(_ => conn.release())
-                        .catch(err => { console.error(`[GT1] ${err}`); conn.release() });
-                })
-                .catch(err => { console.error(`[GT2] ${err}`); reject(err) })
-        });
-    },
+							// Sort by number of reactions needed
+							filteredRows.sort(function(x, y) {
+								if (x.Count < y.Count)
+									return -1;
+								else if (x.Count > y.Count)
+									return 1;
+								return 0;
+							});
+							resolve(filteredRows);
+						})
+						.then(_ => conn.release())
+						.catch(err => { console.error(`[GT1] ${err}`); conn.release() });
+				})
+				.catch(err => { console.error(`[GT2] ${err}`); reject(err) })
+		});
+	},
 
-    /**
-     * Gets the Discord Snowflake (String) for the ID of the Role that is used to punish people with too many
-     * reactions on a message
-     * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
-     * @returns {Promise} - resolve contains ID of role, reject contains error
-     */
-    getPunishRole: function(serverId) {
-        return new Promise((resolve, reject) => {
-            pool.getConnection()
-                .then(conn => {
-                    conn.query("SELECT Value FROM Config WHERE Property = 'PunishRoleId' AND Server = ?", [serverId])
-                        .then(rows => {
-                            // Ideally, there should never be more than 1, so I'm not going to bother handling the rest
-                            if (rows.length >= 1) {
-                                resolve(rows[0].Value);
-                            } else {
-                                reject();
-                            }
-                        })
-                        .then(_ => conn.release())
-                        .catch(err => console.error(`[GPR1] ${err}`));
-                })
-                .catch(err => { console.error(`[GPR2] ${err}`); reject(err) });
-        })
-    },
+	/**
+	 * Gets the Discord Snowflake (String) for the ID of the Role that is used to punish people with too many
+	 * reactions on a message
+	 * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
+	 * @returns {Promise} - resolve contains ID of role, reject contains error
+	 */
+	getPunishRole: function(serverId) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query("SELECT Value FROM Config WHERE Property = 'PunishRoleId' AND Server = ?", [serverId])
+						.then(rows => {
+							// Ideally, there should never be more than 1, so I'm not going to bother handling the rest
+							if (rows.length >= 1) {
+								resolve(rows[0].Value);
+							} else {
+								reject();
+							}
+						})
+						.then(_ => conn.release())
+						.catch(err => console.error(`[GPR1] ${err}`));
+				})
+				.catch(err => { console.error(`[GPR2] ${err}`); reject(err) });
+		})
+	},
 
-    /**
-     * Punishes a specific user by giving them the punish role and logging when the user was initially punished.
-     * Note: Function takes a `Discord.Message` because bot needs to reference the message later to determine when
-     *       to release the user
-     * @param {Discord.Message} msg The message that caused the user to be punished
-     * @returns {Promise} - Resolve contains nothing, reject contains error
-     */
-    punishUser: function(msg) {
-        return new Promise((resolve, reject) => {
-            pool.getConnection()
-                .then(conn => {
-                    let _member = msg.member;
-                    conn.query(`SELECT UserId FROM Horny WHERE UserId = ?`, [_member.id])
-                        .then(rows => {
-                            // Make sure user isn't already being punished
-                            if (rows.length == 0) {
-                                helper.getPunishRole(msg.guild.id)
-                                    .then(roleId => {
-                                        // Log user as being punished (database sets time on insert)
-                                        conn.query(
-                                            "INSERT INTO Horny (UserId, MessageId, ChannelId, GuildId) VALUES (?, ?, ?, ?)",
-                                            [_member.id, msg.id, msg.channel.id, msg.guild.id]);
-                                        _member.roles.add(roleId);
-                                    })
-                                    .catch(err => { console.error(`[PU1] ${err}`); reject(err); })
-                            }
-                        })
-                        .then(_ => conn.release())
-                        .catch(err => {
-                            conn.release();
-                            console.error(`[PU2] ${err}`);
-                            reject(err);
-                        });
-                })
-                .then(resolve) // only resolve once everything is done
-                .catch(dbErr => {
-                    console.error(`[PU3] ${dbErr}`);
-                    reject(dbErr);
-                });
-        });
-    },
+	/**
+	 * Punishes a specific user by giving them the punish role and logging when the user was initially punished.
+	 * Note: Function takes a `Discord.Message` because bot needs to reference the message later to determine when
+	 *       to release the user
+	 * @param {Discord.Message} msg The message that caused the user to be punished
+	 * @returns {Promise} - Resolve contains nothing, reject contains error
+	 */
+	punishUser: function(msg) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					let _member = msg.member;
+					conn.query(`SELECT UserId FROM Horny WHERE UserId = ?`, [_member.id])
+						.then(rows => {
+							// Make sure user isn't already being punished
+							if (rows.length == 0) {
+								helper.getPunishRole(msg.guild.id)
+									.then(roleId => {
+										// Log user as being punished (database sets time on insert)
+										conn.query(
+											"INSERT INTO Horny (UserId, MessageId, ChannelId, GuildId) VALUES (?, ?, ?, ?)",
+											[_member.id, msg.id, msg.channel.id, msg.guild.id]);
+										_member.roles.add(roleId);
+									})
+									.catch(err => { console.error(`[PU1] ${err}`); reject(err); })
+							}
+						})
+						.then(_ => conn.release())
+						.catch(err => {
+							conn.release();
+							console.error(`[PU2] ${err}`);
+							reject(err);
+						});
+				})
+				.then(resolve) // only resolve once everything is done
+				.catch(dbErr => {
+					console.error(`[PU3] ${dbErr}`);
+					reject(dbErr);
+				});
+		});
+	},
 
-    /**
-     * Checks to see if any users need to be freed from punishment.
-     * Note: This does not guarantee anyone will be released, only that if user(s) have served
-     *       enough time that they will be released.
-     * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
-     * @returns {Promise} - Resolve contains nothing, reject contains error
-     */
-    releaseUsers: function(client) {
-        return new Promise((resolve, reject) => {
-            pool.getConnection()
-                .then(conn => {
-                    conn.query("SELECT Id, UserId, MessageId, ChannelId, GuildId, Time FROM Horny")
-                        .then(rows => {
-                            // Check if anyone is currently being punished
-                            if (rows.length > 0)
-                                rows.forEach(function(row) {
-                                    // Next few lines just make sure the message still exists in the guild it was sent to
-                                    let _guild = client.guilds.cache.get(row.GuildId);
-                                    if (_guild) {
-                                        let _channel = _guild.channels.cache.get(row.ChannelId);
-                                        if (_channel) {
-                                            let msg = _channel.messages.cache.get(row.MessageId);
-                                            if (msg) {
-                                                // Count how many reactions are still on message and just based off real-time value
-                                                // (note: if someone removes their reaction, it shortens the time)
-                                                let reaction = msg.reactions.cache.get('🔞');
-                                                let total = reaction ? reaction.count : 0;
-                                                let minutes = (new Date() - row.Time) / 1000 / 60;
-                                                let sentenceTime = 0; // default to no time in case removed reactions make time below server default
-                                                
-                                                helper.getThresholds(msg.guild.id)
-                                                    .then(thresholds => {
-                                                        // Set `sentenceTime` to maximum punishment, defined per server/guild
-                                                        for (let i = 0; i < thresholds.length; i++)
-                                                            if (total >= thresholds[i].Count)
-                                                                sentenceTime = thresholds[i].Time
-                                                        
-                                                        // Check if user has served proper time
-                                                        if (minutes > sentenceTime) {
-                                                            helper.getPunishRole(msg.guild.id)
-                                                                .then(roleId => {
-                                                                    // Remove punishment role & entry from database - they're free!
-                                                                    _guild.members.cache.get(row.UserId).roles.remove(roleId);
-                                                                    conn.query("DELETE FROM Horny WHERE Id = ?", [row.Id]);
-                                                                })
-                                                                .catch(err => { console.error(`[RU1] ${err}`); reject(err); });
-                                                        }
-                                                    })
-                                                    .catch(err => { console.error(`[RU2] ${err}`); reject(err) });
-                                            }
-                                        }
-                                    }
-                                });
-                        })
-                        .then(_res => conn.release())
-                        .catch(err => {
-                            conn.release();
-                            console.error(`[RU3] ${err}`);
-                            reject(err);
-                        });
-                })
-                .then(resolve) // only resolve once everything is done
-                .catch(err => { console.error(`[RU4] ${err}`); reject(err); });
-        });
-    }
+	/**
+	 * Checks to see if any users need to be freed from punishment.
+	 * Note: This does not guarantee anyone will be released, only that if user(s) have served
+	 *       enough time that they will be released.
+	 * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
+	 * @returns {Promise} - Resolve contains nothing, reject contains error
+	 */
+	releaseUsers: function(client) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query("SELECT Id, UserId, MessageId, ChannelId, GuildId, Time FROM Horny")
+						.then(rows => {
+							// Check if anyone is currently being punished
+							if (rows.length > 0)
+								rows.forEach(function(row) {
+									// Next few lines just make sure the message still exists in the guild it was sent to
+									let _guild = client.guilds.cache.get(row.GuildId);
+									if (_guild) {
+										let _channel = _guild.channels.cache.get(row.ChannelId);
+										if (_channel) {
+											let msg = _channel.messages.cache.get(row.MessageId);
+											if (msg) {
+												// Count how many reactions are still on message and just based off real-time value
+												// (note: if someone removes their reaction, it shortens the time)
+												let reaction = msg.reactions.cache.get('🔞');
+												let total = reaction ? reaction.count : 0;
+												let minutes = (new Date() - row.Time) / 1000 / 60;
+												let sentenceTime = 0; // default to no time in case removed reactions make time below server default
+												
+												helper.getThresholds(msg.guild.id)
+													.then(thresholds => {
+														// Set `sentenceTime` to maximum punishment, defined per server/guild
+														for (let i = 0; i < thresholds.length; i++)
+															if (total >= thresholds[i].Count)
+																sentenceTime = thresholds[i].Time
+														
+														// Check if user has served proper time
+														if (minutes > sentenceTime) {
+															helper.getPunishRole(msg.guild.id)
+																.then(roleId => {
+																	// Remove punishment role & entry from database - they're free!
+																	_guild.members.cache.get(row.UserId).roles.remove(roleId);
+																	conn.query("DELETE FROM Horny WHERE Id = ?", [row.Id]);
+																})
+																.catch(err => { console.error(`[RU1] ${err}`); reject(err); });
+														}
+													})
+													.catch(err => { console.error(`[RU2] ${err}`); reject(err) });
+											}
+										}
+									}
+								});
+						})
+						.then(_res => conn.release())
+						.catch(err => {
+							conn.release();
+							console.error(`[RU3] ${err}`);
+							reject(err);
+						});
+				})
+				.then(resolve) // only resolve once everything is done
+				.catch(err => { console.error(`[RU4] ${err}`); reject(err); });
+		});
+	}
 }
 
 module.exports = helper;

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -25,8 +25,8 @@ class Threshold {
 	 * @param {Int} time The amount of minutes to be punished for the amount of reactions
 	 */
 	constructor(count=0, time=0) {
-		this.Count = count;
-		this.Time = time;
+		this.Count = Number.parseInt(count) || 0;
+		this.Time = Number.parseInt(time) || 0;
 	}
 
 	/** Serializes the object to a string in the format "Count:Time" */
@@ -258,7 +258,7 @@ const helper = {
 			let thresholdChangeType = 0; // 0 = add, 1 = update
 			pool.getConnection()
 				.then(conn => {
-					conn.query(`SELECT Id, Value FROM Config WHERE SERVER = '${serverId}' AND Property = 'ReactionThreshold'`)
+					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
 						.then(rows => {
 							if (rows.length > 0) {
 								let thresholds = [];
@@ -268,7 +268,7 @@ const helper = {
 									let result = Threshold.regex.exec(row.Value);
 									if (result) {
 										let threshold = new Threshold(result[1], result[2]);
-										threshold.Id = row.Id;
+										threshold.Id = Number.parseInt(row.Id);
 										thresholds.push(threshold);
 									}
 								});
@@ -278,8 +278,8 @@ const helper = {
 									if (threshold.Count == newThreshold.Count) {
 										found = true;
 										thresholdChangeType = 1;
-										conn.query(`UPDATE Config SET Value = '${newThreshold.serialized}' 
-											WHERE Id = ${threshold.Id}`)
+										conn.query(`UPDATE Config SET Value = ? WHERE Id = ? AND Server = ? AND Property = 'ReactionThreshold'`, 
+											[newThreshold.serialized, threshold.Id, serverId])
 											.catch(updateErr => {
 												conn.release();
 												console.error(`[ST1] ${updateErr}`);
@@ -290,7 +290,8 @@ const helper = {
 
 								if (!found) {
 									conn.query(`INSERT INTO Config (Property, Type, Value, Server) 
-										VALUES ('ReactionThreshold', 'Threshold', '${newThreshold.serialized}', '${serverId}')`)
+										VALUES ('ReactionThreshold', 'Threshold', ?, ?)`,
+										[newThreshold.serialized, serverId])
 										.catch(insertErr => {
 											conn.release();
 											console.error(`[ST2] ${insertErr}`);
@@ -307,6 +308,45 @@ const helper = {
 						})
 				})
 				.catch(err => { console.error(`[ST4] ${err}`); reject(err); });
+		});
+	},
+
+	removeThreshold: function(serverId, count) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
+						.then(rows => {
+							if (rows.length > 0) {
+								rows.forEach(function(row) {
+									let result = Threshold.regex.exec(row.Value);
+									if (result) {
+										let threshold = new Threshold(result[1], 0);
+										threshold.Id = Number.parseInt(row.Id);
+
+										if (threshold.Count == count) {
+											conn.query(`DELETE FROM Config WHERE Server = ? AND Property = 'ReactionThreshold' AND Id = ?`,
+											[serverId, row.Id])
+												.then(() => { 
+													conn.close();
+													resolve(0);
+												})
+												.catch(err => { console.error(`[RT1] ${err}`); reject(err); })
+										}
+									}
+								});
+							} else {
+								resolve(1);
+							}
+						})
+						.then(_ => conn.release())
+						.catch(err => {
+							conn.release();
+							console.error(`[RT] ${err}`);
+							reject(err);
+						})
+				})
+				.catch(err => { console.error(`[RT] ${err}`); reject(err); });
 		});
 	}
 }

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 // Mariadb stuff
 const mariadb = require('mariadb');
 const connectionString = process.env.JAWSDB_MARIA_URL;
-const sqlRegex = /mysql:\/\/(\w+):(\w+)@(.*):(\d+)\/(\w+)/g;
+const sqlRegex = /mysql:\/\/(\w+):(\w+)@(.*):(\d+)\/(\w+)/; // connection string format: mysql://<user>:<pass>@<domain.tld>:<port>/<default-schema>
 const result = sqlRegex.exec(connectionString);
 const pool = mariadb.createPool({
     user: result[1], password: result[2],
@@ -18,8 +18,8 @@ const pool = mariadb.createPool({
  */
 class Threshold {
     /**
-     * @param {Int} count 
-     * @param {Int} time 
+     * @param {Int} count The amount of reactions required
+     * @param {Int} time The amount of minutes to be punished for the amount of reactions
      */
     constructor(count=0, time=0) {
         this.Count = count;

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -17,6 +17,9 @@ const pool = mariadb.createPool({
  * some number of minutes (`Time`) as a punishment.
  */
 class Threshold {
+	/** The regex to match a string value to Threshold object */
+	static regex = /(\d+):(\d+)/;
+
 	/**
 	 * @param {Int} count The amount of reactions required
 	 * @param {Int} time The amount of minutes to be punished for the amount of reactions
@@ -25,9 +28,16 @@ class Threshold {
 		this.Count = count;
 		this.Time = time;
 	}
+
+	/** Serializes the object to a string in the format "Count:Time" */
+	get serialized() {
+		return `${this.Count}:${this.Time}`;
+	}
 }
 
 const helper = {
+	Threshold,
+
 	/**
 	 * Does all first-time startup code relating to the database. As of now,
 	 * it just frees everyone that was being punished.
@@ -87,9 +97,8 @@ const helper = {
 
 							// Threshold format stored in database as `x:y` where x (int) = number of reactions needed,
 							// y (int) = number of minutes to punish for `x` total (or more if no value in database higher than x) reactions
-							const regex = /(\d+):(\d+)/;
 							for (let i = 0; i < rows.length; i++) {
-								let result = regex.exec(rows[i].Value);
+								let result = Threshold.regex.exec(rows[i].Value);
 								filteredRows.push(new Threshold(Number.parseInt(result[1]), Number.parseInt(result[2])));
 							}
 
@@ -241,6 +250,63 @@ const helper = {
 				})
 				.then(resolve) // only resolve once everything is done
 				.catch(err => { console.error(`[RU4] ${err}`); reject(err); });
+		});
+	},
+
+	setThreshold: function(serverId, newThreshold) {
+		return new Promise((resolve, reject) => {
+			let thresholdChangeType = 0; // 0 = add, 1 = update
+			pool.getConnection()
+				.then(conn => {
+					conn.query(`SELECT Id, Value FROM Config WHERE SERVER = '${serverId}' AND Property = 'ReactionThreshold'`)
+						.then(rows => {
+							if (rows.length > 0) {
+								let thresholds = [];
+								let found = false;
+
+								rows.forEach(function(row) {
+									let result = Threshold.regex.exec(row.Value);
+									if (result) {
+										let threshold = new Threshold(result[1], result[2]);
+										threshold.Id = row.Id;
+										thresholds.push(threshold);
+									}
+								});
+
+								for (let i = 0; i < thresholds.length; i++) {
+									let threshold = thresholds[i];
+									if (threshold.Count == newThreshold.Count) {
+										found = true;
+										thresholdChangeType = 1;
+										conn.query(`UPDATE Config SET Value = '${newThreshold.serialized}' 
+											WHERE Id = ${threshold.Id}`)
+											.catch(updateErr => {
+												conn.release();
+												console.error(`[ST1] ${updateErr}`);
+												reject(updateErr);
+											});
+									}
+								}
+
+								if (!found) {
+									conn.query(`INSERT INTO Config (Property, Type, Value, Server) 
+										VALUES ('ReactionThreshold', 'Threshold', '${newThreshold.serialized}', '${serverId}')`)
+										.catch(insertErr => {
+											conn.release();
+											console.error(`[ST2] ${insertErr}`);
+											reject(insertErr);
+										});
+								}
+							}
+						})
+						.then(_ => { conn.release(); resolve(thresholdChangeType); })
+						.catch(err => {
+							conn.release();
+							console.error(`[ST3] ${err}`);
+							reject(err);
+						})
+				})
+				.catch(err => { console.error(`[ST4] ${err}`); reject(err); });
 		});
 	}
 }

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -342,11 +342,27 @@ const helper = {
 						.then(_ => conn.release())
 						.catch(err => {
 							conn.release();
-							console.error(`[RT] ${err}`);
+							console.error(`[RT2] ${err}`);
 							reject(err);
 						})
 				})
-				.catch(err => { console.error(`[RT] ${err}`); reject(err); });
+				.catch(err => { console.error(`[RT3] ${err}`); reject(err); });
+		});
+	},
+
+	viewThresholds: function(serverId) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query(`SELECT Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`)
+						.then(rows => {
+							if (rows.length == 0) {
+								msg.channel.send('No thresholds exist for this server. :fearful:');
+							}
+						})
+						.catch(err => { console.error(`[VT] ${err}`); reject(err); });
+				})
+				.catch(err => { console.error(`[VT] ${err}`); reject(err); })
 		});
 	}
 }

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -12,6 +12,11 @@ const pool = mariadb.createPool({
 	connectionLimit: 5
 });
 
+function plural(number) {
+	number = Number.parseInt(number);
+	return number > 1 ? 's' : '';
+}
+
 /**
  * A struct for storing the minimum number of reactions (`Count`) to warrant
  * some number of minutes (`Time`) as a punishment.
@@ -260,9 +265,10 @@ const helper = {
 				.then(conn => {
 					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
 						.then(rows => {
+							let found = false;
+
 							if (rows.length > 0) {
 								let thresholds = [];
-								let found = false;
 
 								rows.forEach(function(row) {
 									let result = Threshold.regex.exec(row.Value);
@@ -287,17 +293,17 @@ const helper = {
 											});
 									}
 								}
+							}
 
-								if (!found) {
-									conn.query(`INSERT INTO Config (Property, Type, Value, Server) 
-										VALUES ('ReactionThreshold', 'Threshold', ?, ?)`,
-										[newThreshold.serialized, serverId])
-										.catch(insertErr => {
-											conn.release();
-											console.error(`[ST2] ${insertErr}`);
-											reject(insertErr);
-										});
-								}
+							if (!found) {
+								conn.query(`INSERT INTO Config (Property, Type, Value, Server) 
+									VALUES ('ReactionThreshold', 'Threshold', ?, ?)`,
+									[newThreshold.serialized, serverId])
+									.catch(insertErr => {
+										conn.release();
+										console.error(`[ST2] ${insertErr}`);
+										reject(insertErr);
+									});
 							}
 						})
 						.then(_ => { conn.release(); resolve(thresholdChangeType); })
@@ -354,12 +360,30 @@ const helper = {
 		return new Promise((resolve, reject) => {
 			pool.getConnection()
 				.then(conn => {
-					conn.query(`SELECT Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`)
+					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
 						.then(rows => {
 							if (rows.length == 0) {
-								msg.channel.send('No thresholds exist for this server. :fearful:');
+								resolve('No thresholds exist for this server. :fearful:');
+							} else {
+								let thresholds = '**Server Thresholds:**\n```';
+								for (let i = 0; i < rows.length; i++) {
+									let row = rows[i];
+									let result = Threshold.regex.exec(row.Value);
+									let threshold = new Threshold(result[1], result[2]);
+									if (result) {
+										thresholds += 
+											`${result[1]} react${plural(threshold.Count)} = ${result[2]} minute${plural(threshold.Time)}\n`;
+									} else {
+										console.error(`Invalid threshold value ([ID:${row.Id}]${row.Value})`);
+										reject(`Invalid threshold value ([ID:${row.Id}]${row.Value})`);
+									}
+								}
+
+								thresholds = thresholds.substr(0, thresholds.length - 1) + '```';
+								resolve(thresholds);
 							}
 						})
+						.then(() => conn.release())
 						.catch(err => { console.error(`[VT] ${err}`); reject(err); });
 				})
 				.catch(err => { console.error(`[VT] ${err}`); reject(err); })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.2.0-BETA",
+  "version": "1.2.0",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.2.0 BETA",
+  "version": "1.2.0-BETA",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.2.0",
+  "version": "1.2.0 BETA",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Added ability to control reaction thresholds (see #5) with commands. New commands include:

**!threshold <add/set> <count> <time>**
_Adds a new threshold, or updates an existing threshold (using `count` as the identifier) for a given server_

**!threshold <del/delete/rem/remove> <count>**
_Removes the threshold for `count` in a given server_

**!threshold <list/view>**
_Shows all thresholds in a server, if any exist._

**!threshold help**
_Shows a more detailed help message with all the threshold commands_

Every command has multiple options just because I wanted to give everyone variety or to use whatever verbiage they prefer.