### PR TITLE
Ignore channels feature

### DIFF
--- a/commands/ignore.js
+++ b/commands/ignore.js
@@ -10,81 +10,81 @@ module.exports = {
 	description: 'Manages channels the bot will ignore commands from',
 	permission: 0, // Permission level
 	execute(msg, args) {
-        const command = prefix + module.exports.name;
-        
+		const command = prefix + module.exports.name;
+		
 		switch(args[0]) {
-            case 'channels':
-            case 'list':
-                dbHelper.getIgnoreChannels(msg.guild.id)
-                    .then(channels => {
-                        if (channels.length > 0) {
-                            let reply = "Commands executed in the following channels are ignored:\n";
-                            channels.forEach(function(channel) { reply += `<#${channel}>, `});
-                            reply = reply.substr(0, reply.length - 2);
-                            msg.channel.send(reply);
-                        } else {
-                            msg.channel.send("Currently, the bot isn't ignoring any channels.");
-                        }
-                    })
-                    .catch(err => { throw err; });
-                break;
-            case 'add':
-                let properAddUsage = `${command} add <channel>`;
-                if (args.length == 2) {
-                    let result = CHANNEL_REGEX.exec(args[1]);
-                    if (result) {
-                        let channelId = result[1];
-                        dbHelper.addIgnoreChannel(msg.guild.id, channelId)
-                            .then(status => {
-                                if (status == 0)
-                                    msg.channel.send(`Successfully added <#${channelId}> to ignored channels.`)
-                                else if (status == 1)
-                                    msg.channel.send(`Channel <#${channelId}> is already being ignored.`);
-                                else
-                                    throw `Unexpected return code returned from \`${properAddUsage.substr(0, properAddUsage.length - 9)}<#${channelId}>\``;
-                            })
-                            .catch(err => { throw err; });
-                    } else {
-                        msg.reply(`Invalid argument. Please specify a channel. Proper usage: ${properAddUsage}.`);
-                    }
-                } else {
-                    msg.reply(`Invalid arguments given. Proper usage: ${properAddUsage}.`);
-                }
-                break;
-            case 'del':
-            case 'delete':
-            case 'rem':
-            case 'remove':
-                let properDelUsage = `${command} <del/delete/rem/remove> <channel>`;
-                if (args.length == 2) {
-                    let result = CHANNEL_REGEX.exec(args[1]);
-                    if (result) {
-                        let channelId = result[1];
-                        dbHelper.removeIgnoreChannel(msg.guild.id, channelId)
-                            .then(status => {
-                                if (status == 0) {
-                                    msg.channel.send(`Successfully removed <#${channelId}> from ignored channels`);
-                                } else if (status == 1) {
-                                    msg.channel.send(`This server has no channels being ignored. Please add some before trying to delete them. :slight_smile:`);
-                                } else if (status == 2) {
-                                    msg.channel.send(`The channel <#${channelId}> isn't currently being ignored? Did you really just try that? Crigne?????`);
-                                } else {
-                                    throw `Unexpected return code returned from \`${properDelUsage.substr(0, properDelUsage.length - 9)}<#${channelId}>\``;
-                                }
-                            })
-                            .catch(err => { throw err; });
-                    } else {
-                        msg.reply(`Invalid arguments given. Proper usage: ${properDelUsage}`);
-                    }
-                } else {
-                    msg.reply(`Invalid arguments given. ${properDelUsage}.`);
-                }
-                break;
-            case 'help':
-                break;
-            default:
-                msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`);
-                break;
-        }
+			case 'channels':
+			case 'list':
+				dbHelper.getIgnoreChannels(msg.guild.id)
+					.then(channels => {
+						if (channels.length > 0) {
+							let reply = "Commands executed in the following channels are ignored:\n";
+							channels.forEach(function(channel) { reply += `<#${channel}>, `});
+							reply = reply.substr(0, reply.length - 2);
+							msg.channel.send(reply);
+						} else {
+							msg.channel.send("Currently, the bot isn't ignoring any channels.");
+						}
+					})
+					.catch(err => { throw err; });
+				break;
+			case 'add':
+				let properAddUsage = `${command} add <channel>`;
+				if (args.length == 2) {
+					let result = CHANNEL_REGEX.exec(args[1]);
+					if (result) {
+						let channelId = result[1];
+						dbHelper.addIgnoreChannel(msg.guild.id, channelId)
+							.then(status => {
+								if (status == 0)
+									msg.channel.send(`Successfully added <#${channelId}> to ignored channels.`)
+								else if (status == 1)
+									msg.channel.send(`Channel <#${channelId}> is already being ignored.`);
+								else
+									throw `Unexpected return code returned from \`${properAddUsage.substr(0, properAddUsage.length - 9)}<#${channelId}>\``;
+							})
+							.catch(err => { throw err; });
+					} else {
+						msg.reply(`Invalid argument. Please specify a channel. Proper usage: ${properAddUsage}.`);
+					}
+				} else {
+					msg.reply(`Invalid arguments given. Proper usage: ${properAddUsage}.`);
+				}
+				break;
+			case 'del':
+			case 'delete':
+			case 'rem':
+			case 'remove':
+				let properDelUsage = `${command} <del/delete/rem/remove> <channel>`;
+				if (args.length == 2) {
+					let result = CHANNEL_REGEX.exec(args[1]);
+					if (result) {
+						let channelId = result[1];
+						dbHelper.removeIgnoreChannel(msg.guild.id, channelId)
+							.then(status => {
+								if (status == 0) {
+									msg.channel.send(`Successfully removed <#${channelId}> from ignored channels`);
+								} else if (status == 1) {
+									msg.channel.send(`This server has no channels being ignored. Please add some before trying to delete them. :slight_smile:`);
+								} else if (status == 2) {
+									msg.channel.send(`The channel <#${channelId}> isn't currently being ignored? Did you really just try that? Crigne?????`);
+								} else {
+									throw `Unexpected return code returned from \`${properDelUsage.substr(0, properDelUsage.length - 9)}<#${channelId}>\``;
+								}
+							})
+							.catch(err => { throw err; });
+					} else {
+						msg.reply(`Invalid arguments given. Proper usage: ${properDelUsage}`);
+					}
+				} else {
+					msg.reply(`Invalid arguments given. ${properDelUsage}.`);
+				}
+				break;
+			case 'help':
+				break;
+			default:
+				msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`);
+				break;
+		}
 	}
 };

--- a/commands/ignore.js
+++ b/commands/ignore.js
@@ -1,0 +1,43 @@
+// Helper module for anything database-related
+const dbHelper = require('../lib/database-helper');
+
+let { prefix } = require('../config.json');
+
+module.exports = {
+	name: 'ignore',
+	description: 'Manages channels the bot will ignore commands from',
+	permission: 0, // Permission level
+	execute(msg, args) {
+        const command = prefix + module.exports.name;
+        
+		switch(args[0]) {
+            case 'channels':
+            case 'list':
+                dbHelper.getIgnoreChannels(msg.guild.id)
+                    .then(channels => {
+                        if (channels.length > 0) {
+                            let reply = "Commands executed in the following channels are ignored:\n";
+                            channels.forEach(function(channel) { reply += `<#${channel}>, `});
+                            reply = reply.substr(0, reply.length - 2);
+                            msg.channel.send(reply);
+                        } else {
+                            msg.channel.send("Currently, the bot isn't ignoring any channels.");
+                        }
+                    })
+                    .catch(err => { throw err; });
+                break;
+            case 'add':
+                break;
+            case 'del':
+            case 'delete':
+            case 'rem':
+            case 'remove':
+                break;
+            case 'help':
+                break;
+            default:
+                msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`);
+                break;
+        }
+	}
+};

--- a/commands/ignore.js
+++ b/commands/ignore.js
@@ -3,6 +3,8 @@ const dbHelper = require('../lib/database-helper');
 
 let { prefix } = require('../config.json');
 
+const CHANNEL_REGEX = /<#(\d+)>/;
+
 module.exports = {
 	name: 'ignore',
 	description: 'Manages channels the bot will ignore commands from',
@@ -27,6 +29,27 @@ module.exports = {
                     .catch(err => { throw err; });
                 break;
             case 'add':
+                let properAddUsage = `Proper usage: \`${command} add <channel>\``;
+                if (args.length == 2) {
+                    let result = CHANNEL_REGEX.exec(args[1]);
+                    if (result) {
+                        let channelId = result[1];
+                        dbHelper.addIgnoreChannel(msg.guild.id, channelId)
+                            .then(status => {
+                                if (status == 0)
+                                    msg.channel.send(`Successfully added <#${channelId}> to ignored channels.`)
+                                else if (status == 1)
+                                    msg.channel.send(`Channel <#${channelId}> is already being ignored.`);
+                                else
+                                    throw `Unexpected return code returned from \`${command} add <#${channelId}>\``;
+                            })
+                            .catch(err => { throw err; });
+                    } else {
+                        msg.reply(`Invalid argument. Please specify a channel.\n${properAddUsage}`);
+                    }
+                } else {
+                    msg.reply(`Invalid arguments given. ${properAddUsage}`);
+                }
                 break;
             case 'del':
             case 'delete':

--- a/commands/ignore.js
+++ b/commands/ignore.js
@@ -29,7 +29,7 @@ module.exports = {
                     .catch(err => { throw err; });
                 break;
             case 'add':
-                let properAddUsage = `Proper usage: \`${command} add <channel>\``;
+                let properAddUsage = `${command} add <channel>`;
                 if (args.length == 2) {
                     let result = CHANNEL_REGEX.exec(args[1]);
                     if (result) {
@@ -41,20 +41,44 @@ module.exports = {
                                 else if (status == 1)
                                     msg.channel.send(`Channel <#${channelId}> is already being ignored.`);
                                 else
-                                    throw `Unexpected return code returned from \`${command} add <#${channelId}>\``;
+                                    throw `Unexpected return code returned from \`${properAddUsage.substr(0, properAddUsage.length - 9)}<#${channelId}>\``;
                             })
                             .catch(err => { throw err; });
                     } else {
-                        msg.reply(`Invalid argument. Please specify a channel.\n${properAddUsage}`);
+                        msg.reply(`Invalid argument. Please specify a channel. Proper usage: ${properAddUsage}.`);
                     }
                 } else {
-                    msg.reply(`Invalid arguments given. ${properAddUsage}`);
+                    msg.reply(`Invalid arguments given. Proper usage: ${properAddUsage}.`);
                 }
                 break;
             case 'del':
             case 'delete':
             case 'rem':
             case 'remove':
+                let properDelUsage = `${command} <del/delete/rem/remove> <channel>`;
+                if (args.length == 2) {
+                    let result = CHANNEL_REGEX.exec(args[1]);
+                    if (result) {
+                        let channelId = result[1];
+                        dbHelper.removeIgnoreChannel(msg.guild.id, channelId)
+                            .then(status => {
+                                if (status == 0) {
+                                    msg.channel.send(`Successfully removed <#${channelId}> from ignored channels`);
+                                } else if (status == 1) {
+                                    msg.channel.send(`This server has no channels being ignored. Please add some before trying to delete them. :slight_smile:`);
+                                } else if (status == 2) {
+                                    msg.channel.send(`The channel <#${channelId}> isn't currently being ignored? Did you really just try that? Crigne?????`);
+                                } else {
+                                    throw `Unexpected return code returned from \`${properDelUsage.substr(0, properDelUsage.length - 9)}<#${channelId}>\``;
+                                }
+                            })
+                            .catch(err => { throw err; });
+                    } else {
+                        msg.reply(`Invalid arguments given. Proper usage: ${properDelUsage}`);
+                    }
+                } else {
+                    msg.reply(`Invalid arguments given. ${properDelUsage}.`);
+                }
                 break;
             case 'help':
                 break;

--- a/commands/threshold.js
+++ b/commands/threshold.js
@@ -5,23 +5,24 @@ let { prefix } = require('../config.json');
 
 module.exports = {
 	name: 'threshold',
-	description: `Manages the server reaction thresholds for punishing users. \`${prefix}${module.exports.name} help\` for more info.`,
+	description: `Manages the server reaction thresholds for punishing users.`,
 	permission: 1,
 	execute(msg, args) {
 		// Convert all arguments to lowercase
 		args.forEach(function(arg, index) { args[index] = arg.toLowerCase() });
 		const command = prefix + module.exports.name;
-		const properUsage = `Proper usage: \`${command} add <count> <time>\``;
 
 		switch(args[0]) {
 			case 'add':
 			case 'set':
+				const properAddUsage = `Proper usage: \`${command} add <count> <time>\``;
+
 				if (args.length == 3) {
-					let count = Number.parseInt(args[1]);
-					let time = Number.parseInt(args[2]);
+					const count = Number.parseInt(args[1]);
+					const time = Number.parseInt(args[2]);
 
 					if (isNaN(count) || isNaN(time)) {
-						msg.reply(`Invalid arguments given. ${properUsage}.`);
+						msg.reply(`Invalid arguments given. ${properAddUsage}.`);
 						return;
 					}
 
@@ -35,7 +36,7 @@ module.exports = {
 							.catch(err => { throw err });
 					}
 				} else {
-					msg.reply(`Invalid number of arguments. ${properUsage}.`);
+					msg.reply(`Invalid number of arguments. ${properAddUsage}.`);
 				}
 				break;
 			case 'list':
@@ -48,11 +49,11 @@ module.exports = {
 			case 'delete':
 			case 'remove':
 			case 'rem':
-				let properUsage = `Proper usage: \`${command} del <count>\``;
+				const properDelUsage = `Proper usage: \`${command} del <count>\``;
 				if (args.length == 2) {
-					let count = Number.parseInt(args[1]);
+					const count = Number.parseInt(args[1]);
 					if (isNaN(count)) {
-						msg.reply(`Invalid arguments given. ${properUsage}.`);
+						msg.reply(`Invalid arguments given. ${properDelUsage}.`);
 						return;
 					}
 
@@ -65,15 +66,17 @@ module.exports = {
 									msg.channel.send(
 										`Successfully removed reaction threshold for ${count} reaction${count > 1 ? 's' : ''}`);
 								} else if (result == 1) {
+									msg.channel.send(`No threshold exists for **${count} reaction${count > 1 ? 's' : ''}**.`);
+								} else if (result == 2) {
 									msg.channel.send('No thresholds exist for this server. Please set some before trying to remove them.');
 								} else {
-									msg.channel.send('Well there wasn\'t an error but this situation wasn\'t covered sooooooo');
+									throw `Unexpected return code returned from \`${command} del ${count}\``;
 								}
 							})
 							.catch(err => { throw err });
 					}
 				} else {
-					msg.reply(`Invalid number of arguments. ${properUsage}.`);
+					msg.reply(`Invalid number of arguments. ${properDelUsage}.`);
 				}
 				break;
 			case 'web':
@@ -103,7 +106,8 @@ usage: ${command} del 3
 Sends the URL for manging thresholds from a web interface.`);
 				break;
 			default:
-				msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`)
+				msg.channel.send(`Invalid argument. Please try \`${command} help\` for help.`);
+				break;
 		}
 	}
 };

--- a/lib/bot-app.js
+++ b/lib/bot-app.js
@@ -36,32 +36,45 @@ client.on('ready', () => {
 client.on('message', msg => {
 	if (!msg.content.startsWith(prefix) || msg.author.bot) return; // if message doesn't start with command prefix or is from bot, ignore
 
-	// Split command into an array (ex: "!ping hello world" => ['!ping', 'hello', 'world'])
-	const args = msg.content.slice(prefix.length).split(/ +/);
-	const cmd = args.shift().toLowerCase();
+	dbHelper.getIgnoreChannels(msg.guild.id)
+		.then(channels => {
+			if (channels.length > 0) {
+				// Ignore commands send in ignored channels
+				if (channels.includes(msg.channel.id)) return;
 
-	// The only built in command - !cmds / !commands. Lists all registered commands w/ a description
-	if (cmd === "commands" || cmd === "cmds") {
-		var cmds = client.commands.values();
-		var bot_reply = "\n";
-		for (var command of cmds) {
-			bot_reply += "`" + prefix + command.name + "`\n" + command.description + "\n\n";
-		}
-		msg.channel.send(bot_reply);
-		return;
-	}
+				// Split command into an array (ex: "!ping hello world" => ['!ping', 'hello', 'world'])
+				const args = msg.content.slice(prefix.length).split(/ +/);
+				const cmd = args.shift().toLowerCase();
 
-	// Ignores if they try to run a command bot doesn't have
-	if (!client.commands.has(cmd)) return;
+				// The only built in command - !cmds / !commands. Lists all registered commands w/ a description
+				if (cmd === "commands" || cmd === "cmds") {
+					var cmds = client.commands.values();
+					var bot_reply = "\n";
+					for (var command of cmds) {
+						bot_reply += "`" + prefix + command.name + "`\n" + command.description + "\n\n";
+					}
+					msg.channel.send(bot_reply);
+					return;
+				}
 
-	// Command was found, so run it and report any errors.
-	try {
-		client.commands.get(cmd).execute(msg, args);
-	} catch(err) {
-		console.error(err);
-		msg.reply('There was an error trying to run this command. Please repeatedly spam the mods until they notice it. Thank you.');
-		msg.channel.send(`\`\`\`\n${err}\`\`\``);
-	}
+				// Ignores if they try to run a command bot doesn't have
+				if (!client.commands.has(cmd)) return;
+
+				// Command was found, so run it and report any errors.
+				try {
+					client.commands.get(cmd).execute(msg, args);
+				} catch(err) {
+					console.error(err);
+					msg.reply('There was an error trying to run this command. Please repeatedly spam the mods until they notice it. Thank you.');
+					msg.channel.send(`\`\`\`\n${err}\`\`\``);
+				}
+			}
+		})
+		.catch(err => {
+			console.error(err);
+			msg.reply('There was an error trying to run this command. Please repeatedly spam the mods until they notice it. Thank you.');
+			msg.channel.send(`\`\`\`\n${err}\`\`\``);
+		});
 });
 
 client.on('messageReactionAdd', (reaction, user) => {

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 
+const { Client, Snowflake, Message } = require('discord.js');
 // Mariadb stuff
 const mariadb = require('mariadb');
 const connectionString = process.env.JAWSDB_MARIA_URL;
@@ -26,8 +27,8 @@ class Threshold {
 	static REGEX = /(\d+):(\d+)/;
 
 	/**
-	 * @param {Int} count The amount of reactions required
-	 * @param {Int} time The amount of minutes to be punished for the amount of reactions
+	 * @param {Number} count The amount of reactions required
+	 * @param {Number} time The amount of minutes to be punished for the amount of reactions
 	 */
 	constructor(count=0, time=0) {
 		this.Count = Number.parseInt(count) || 0;
@@ -48,8 +49,8 @@ const helper = {
 	/**
 	 * Does all first-time startup code relating to the database. As of now,
 	 * it just frees everyone that was being punished.
-	 * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
-	 * @returns {Promise} - reject message contains error, resolve is empty
+	 * @param {Client} client The bot client, used to initialize the bot and sign in
+	 * @returns {Promise<null, Error>} reject message contains error, resolve is empty
 	 */
 	init: function(client) {
 		return new Promise((resolve, reject) => {
@@ -90,8 +91,8 @@ const helper = {
 	 * Gets all the saved thresholds for reactions from the database. This is how
 	 * x reactions = y minutes of punishment is determined.
 	 * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
-	 * @returns {Promise} - resolve contains array of {Threshold}s organized from smallest `Count` to `Largest`, reject contains error
-	 * @see {Threshold}
+	 * @returns {Promise<Array<Threshold>, Error>} resolve contains array of Thresholds organized from smallest `Count` to `Largest`, reject contains error
+	 * @see Threshold
 	 */
 	getThresholds: function(serverId) {
 		return new Promise((resolve, reject) => {
@@ -130,7 +131,7 @@ const helper = {
 	 * Gets the Discord Snowflake (String) for the ID of the Role that is used to punish people with too many
 	 * reactions on a message
 	 * @param {Snowflake} serverId Discord Snowflake (String) for the server / guild
-	 * @returns {Promise} - resolve contains ID of role, reject contains error
+	 * @returns {Promise<Snowflake, Error>} Resolve contains ID of role, reject contains error
 	 */
 	getPunishRole: function(serverId) {
 		return new Promise((resolve, reject) => {
@@ -155,6 +156,7 @@ const helper = {
 	/**
 	 * Gets the Discord Snowflake (String) for the ID of all channels the bot will ignore in a given server
 	 * @param {Snowflake} serverId The server to check for ignored channels
+	 * @returns {Promise<Array<Snowflake>, Error>} Resolve contains array of ignored channels (if any), reject contains error
 	 */
 	getIgnoreChannels: function(serverId) {
 		return new Promise((resolve, reject) => {
@@ -186,8 +188,8 @@ const helper = {
 	 * Punishes a specific user by giving them the punish role and logging when the user was initially punished.
 	 * Note: Function takes a `Discord.Message` because bot needs to reference the message later to determine when
 	 *       to release the user
-	 * @param {Discord.Message} msg The message that caused the user to be punished
-	 * @returns {Promise} - Resolve contains nothing, reject contains error
+	 * @param {Message} msg The message that caused the user to be punished
+	 * @returns {Promise<null, Error>} Resolve contains nothing, reject contains error
 	 */
 	punishUser: function(msg) {
 		return new Promise((resolve, reject) => {
@@ -228,8 +230,8 @@ const helper = {
 	 * Checks to see if any users need to be freed from punishment.
 	 * Note: This does not guarantee anyone will be released, only that if user(s) have served
 	 *       enough time that they will be released.
-	 * @param {Discord.Client} client The bot client, used to initialize the bot and sign in
-	 * @returns {Promise} - Resolve contains nothing, reject contains error
+	 * @param {Client} client The bot client, used to initialize the bot and sign in
+	 * @returns {Promise<null, Error>} Resolve contains nothing, reject contains error
 	 */
 	releaseUsers: function(client) {
 		return new Promise((resolve, reject) => {
@@ -294,6 +296,8 @@ const helper = {
 	 * Adds or overwrites a new reaction {Threshold} for a given server
 	 * @param {Snowflake} serverId The ID of the server to add/overwrite the new threshold
 	 * @param {Threshold} newThreshold The new threshold to add/overwrite to the server
+	 * @returns {Promise<Number, Error>} Resolve contains change type (0 = add, 1 = update), reject contains error]
+	 * @see Threshold
 	 */
 	setThreshold: function(serverId, newThreshold) {
 		return new Promise((resolve, reject) => {
@@ -361,8 +365,9 @@ const helper = {
 
 	/**
 	 * Removes a threshold from a given server, if it exists
-	 * @param {Snowflake} serverId 
-	 * @param {Int} count 
+	 * @param {Snowflake} serverId The ID of the server to remove the threshold
+	 * @param {Number} count The reaction {Threshold} count to search for
+	 * @returns {Promise<Number, Error>} Resolve contains status (0 = removed, 1 = not found, 2 = no thresholds in server), reject contains error
 	 */
 	removeThreshold: function(serverId, count) {
 		return new Promise((resolve, reject) => {
@@ -374,8 +379,10 @@ const helper = {
 								let found = false;
 
 								rows.forEach(function(row) {
+									// Make sure value is stored properly and is an actual Threshold
 									let result = Threshold.REGEX.exec(row.Value);
 									if (result) {
+										// Add ID to object to ensure proper value is deleted
 										let threshold = new Threshold(result[1], 0);
 										threshold.Id = Number.parseInt(row.Id);
 
@@ -393,10 +400,10 @@ const helper = {
 								});
 
 								if (!found) {
-									resolve(1);
+									resolve(1); // Threshold not found
 								}
 							} else {
-								resolve(2);
+								resolve(2); // Server has no thresholds set
 							}
 						})
 						.then(_ => conn.release())
@@ -410,6 +417,12 @@ const helper = {
 		});
 	},
 
+	/**
+	 * Returns a formatted message of all thresholds that exist for a server
+	 * @todo Change from string return type to array of thresholds and make message process array
+	 * @param {Snowflake} serverId The ID of the server to get the threshold(s) from
+	 * @returns {String} A message containing all thresholds, or a message saying there are no thresholds
+	 */
 	viewThresholds: function(serverId) {
 		return new Promise((resolve, reject) => {
 			pool.getConnection()
@@ -428,7 +441,7 @@ const helper = {
 										thresholds += 
 											`${result[1]} react${plural(threshold.Count)} = ${result[2]} minute${plural(threshold.Time)}\n`;
 									} else {
-										console.error(`Invalid threshold value ([ID:${row.Id}]${row.Value})`);
+										console.error(`[VT1] Invalid threshold value ([ID:${row.Id}]${row.Value})`);
 										reject(`Invalid threshold value ([ID:${row.Id}]${row.Value})`);
 									}
 								}
@@ -438,12 +451,18 @@ const helper = {
 							}
 						})
 						.then(() => conn.release())
-						.catch(err => { console.error(`[VT] ${err}`); reject(err); });
+						.catch(err => { console.error(`[VT2] ${err}`); reject(err); });
 				})
-				.catch(err => { console.error(`[VT] ${err}`); reject(err); })
+				.catch(err => { console.error(`[VT3] ${err}`); reject(err); })
 		});
 	},
 
+	/**
+	 * Adds a channel to the bot's ignored channels. Users cannot run commands in ignored channels.
+	 * @param {Snowflake} serverId The ID of the server that has the desired channel
+	 * @param {Snowflake} channelId The ID of the channel to be ignored within the server
+	 * @returns {Promise<Number, Error>} Resolve contains status code (0 = success, 1 = channel already being ignored), reject contains error
+	 */
 	addIgnoreChannel: function(serverId, channelId) {
 		return new Promise((resolve, reject) => {
 			helper.getIgnoreChannels(serverId)
@@ -454,7 +473,7 @@ const helper = {
 								conn.query(
 									`INSERT INTO Config (Property, Type, Value, Server) VALUES ('IgnoreChannel', 'Snowflake', ?, ?)`, 
 									[channelId, serverId])
-									.then(() => { conn.release(); resolve(); })
+									.then(() => { conn.release(); resolve(0); })
 									.catch(err => { 
 										console.error(`[AIC1] ${err}`);
 										conn.release(0);
@@ -466,15 +485,52 @@ const helper = {
 								reject(err);
 							});
 					} else {
-						resolve(1);
+						resolve(1); // channel already being ignored
 					}
 				})
 				.catch(err => { console.error(`[AIC3] ${err}`); reject(err); });
 		})
 	},
 
+	/**
+	 * 
+	 * @param {Snowflake} serverId The ID of the server that has the desired channel
+	 * @param {Snowflake} channelId The ID of the channel to be unignored
+	 * @returns {Promise<Number, Error>} Resolve contains status (0 = success, 1 = no channels are ignored in server, 2 = `channelId` not being ignored), reject contains error
+	 */
 	removeIgnoreChannel: function(serverId, channelId) {
-
+		return new Promise((resolve, reject) => {
+			helper.getIgnoreChannels(serverId)
+				.then(channels => {
+					if (channels.length > 0) {
+						if (channels.includes(channelId)) {
+							pool.getConnection()
+								.then(conn => {
+									conn.query(
+										`DELETE FROM Config WHERE Property = 'IgnoreChannel' AND Server = ? AND Value = ?`,
+										[serverId, channelId])
+										.then(() => { conn.release(); resolve(0); })
+										.catch(err => {
+											console.error(`[RIC1] ${err}`);
+											reject(err);
+										})
+								})
+								.catch(err => {
+									console.error(`[RIC2] ${err}`);
+									reject(err);
+								})
+						} else {
+							resolve(2); // channel not being ignored
+						}
+					} else {
+						resolve(1); // no channels being ignored
+					}
+				})
+				.catch(err => {
+					console.error(`[RIC3] ${err}`);
+					reject(err);
+				})
+		});
 	}
 }
 

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -23,7 +23,7 @@ function plural(number) {
  */
 class Threshold {
 	/** The regex to match a string value to Threshold object */
-	static regex = /(\d+):(\d+)/;
+	static REGEX = /(\d+):(\d+)/;
 
 	/**
 	 * @param {Int} count The amount of reactions required
@@ -39,6 +39,8 @@ class Threshold {
 		return `${this.Count}:${this.Time}`;
 	}
 }
+
+const CHANNEL_REGEX = /<#(\d+)/;
 
 const helper = {
 	Threshold,
@@ -103,7 +105,7 @@ const helper = {
 							// Threshold format stored in database as `x:y` where x (int) = number of reactions needed,
 							// y (int) = number of minutes to punish for `x` total (or more if no value in database higher than x) reactions
 							for (let i = 0; i < rows.length; i++) {
-								let result = Threshold.regex.exec(rows[i].Value);
+								let result = Threshold.REGEX.exec(rows[i].Value);
 								filteredRows.push(new Threshold(Number.parseInt(result[1]), Number.parseInt(result[2])));
 							}
 
@@ -150,6 +152,10 @@ const helper = {
 		})
 	},
 
+	/**
+	 * Gets the Discord Snowflake (String) for the ID of all channels the bot will ignore in a given server
+	 * @param {Snowflake} serverId The server to check for ignored channels
+	 */
 	getIgnoreChannels: function(serverId) {
 		return new Promise((resolve, reject) => {
 			pool.getConnection()
@@ -159,8 +165,8 @@ const helper = {
 							if (rows.length > 0) {
 								// filter out additional added by mariadb
 								let filteredRows = [];
-								rows.forEach(function(val) { filteredRows.push(val); });
-								resolve(filteredRows)
+								rows.forEach(function(val) { filteredRows.push(val.Value); });
+								resolve(filteredRows);
 							} else {
 								resolve([]);
 							}
@@ -174,7 +180,7 @@ const helper = {
 				})
 				.catch(err => { console.error(`[GIC] ${err}`); reject(err); });
 		})
-	}
+	},
 
 	/**
 	 * Punishes a specific user by giving them the punish role and logging when the user was initially punished.
@@ -284,9 +290,16 @@ const helper = {
 		});
 	},
 
+	/**
+	 * Adds or overwrites a new reaction {Threshold} for a given server
+	 * @param {Snowflake} serverId The ID of the server to add/overwrite the new threshold
+	 * @param {Threshold} newThreshold The new threshold to add/overwrite to the server
+	 */
 	setThreshold: function(serverId, newThreshold) {
 		return new Promise((resolve, reject) => {
+			// Used to tell user if the threshold already exists and needs to be updated, or doesn't exist and needs to be added
 			let thresholdChangeType = 0; // 0 = add, 1 = update
+
 			pool.getConnection()
 				.then(conn => {
 					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
@@ -296,8 +309,9 @@ const helper = {
 							if (rows.length > 0) {
 								let thresholds = [];
 
+								// Convert database string format ("int:int") to a Threshold object
 								rows.forEach(function(row) {
-									let result = Threshold.regex.exec(row.Value);
+									let result = Threshold.REGEX.exec(row.Value);
 									if (result) {
 										let threshold = new Threshold(result[1], result[2]);
 										threshold.Id = Number.parseInt(row.Id);
@@ -305,6 +319,7 @@ const helper = {
 									}
 								});
 
+								// Check if threshold exists, and if it does, overwrite it with new settings
 								for (let i = 0; i < thresholds.length; i++) {
 									let threshold = thresholds[i];
 									if (threshold.Count == newThreshold.Count) {
@@ -321,6 +336,7 @@ const helper = {
 								}
 							}
 
+							// Threshold does not exist, so create a new one
 							if (!found) {
 								conn.query(`INSERT INTO Config (Property, Type, Value, Server) 
 									VALUES ('ReactionThreshold', 'Threshold', ?, ?)`,
@@ -343,6 +359,11 @@ const helper = {
 		});
 	},
 
+	/**
+	 * Removes a threshold from a given server, if it exists
+	 * @param {Snowflake} serverId 
+	 * @param {Int} count 
+	 */
 	removeThreshold: function(serverId, count) {
 		return new Promise((resolve, reject) => {
 			pool.getConnection()
@@ -350,13 +371,16 @@ const helper = {
 					conn.query(`SELECT Id, Value FROM Config WHERE Server = ? AND Property = 'ReactionThreshold'`, [serverId])
 						.then(rows => {
 							if (rows.length > 0) {
+								let found = false;
+
 								rows.forEach(function(row) {
-									let result = Threshold.regex.exec(row.Value);
+									let result = Threshold.REGEX.exec(row.Value);
 									if (result) {
 										let threshold = new Threshold(result[1], 0);
 										threshold.Id = Number.parseInt(row.Id);
 
 										if (threshold.Count == count) {
+											found = true;
 											conn.query(`DELETE FROM Config WHERE Server = ? AND Property = 'ReactionThreshold' AND Id = ?`,
 											[serverId, row.Id])
 												.then(() => { 
@@ -367,8 +391,12 @@ const helper = {
 										}
 									}
 								});
+
+								if (!found) {
+									resolve(1);
+								}
 							} else {
-								resolve(1);
+								resolve(2);
 							}
 						})
 						.then(_ => conn.release())
@@ -394,7 +422,7 @@ const helper = {
 								let thresholds = '**Server Thresholds:**\n```';
 								for (let i = 0; i < rows.length; i++) {
 									let row = rows[i];
-									let result = Threshold.regex.exec(row.Value);
+									let result = Threshold.REGEX.exec(row.Value);
 									let threshold = new Threshold(result[1], result[2]);
 									if (result) {
 										thresholds += 
@@ -414,6 +442,14 @@ const helper = {
 				})
 				.catch(err => { console.error(`[VT] ${err}`); reject(err); })
 		});
+	},
+
+	addIgnoreChannel: function(serverId, channelId) {
+
+	},
+
+	removeIgnoreChannel: function(serverId, channelId) {
+
 	}
 }
 

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -40,7 +40,7 @@ class Threshold {
 	}
 }
 
-const CHANNEL_REGEX = /<#(\d+)/;
+const CHANNEL_REGEX = /<#(\d+)>/;
 
 const helper = {
 	Threshold,
@@ -445,7 +445,32 @@ const helper = {
 	},
 
 	addIgnoreChannel: function(serverId, channelId) {
-
+		return new Promise((resolve, reject) => {
+			helper.getIgnoreChannels(serverId)
+				.then(channels => {
+					if (!channels.includes(channelId)) {
+						pool.getConnection()
+							.then(conn => {
+								conn.query(
+									`INSERT INTO Config (Property, Type, Value, Server) VALUES ('IgnoreChannel', 'Snowflake', ?, ?)`, 
+									[channelId, serverId])
+									.then(() => { conn.release(); resolve(); })
+									.catch(err => { 
+										console.error(`[AIC1] ${err}`);
+										conn.release(0);
+										reject(err);
+									});
+							})
+							.catch(err => {
+								console.error(`[AIC2] ${err}`);
+								reject(err);
+							});
+					} else {
+						resolve(1);
+					}
+				})
+				.catch(err => { console.error(`[AIC3] ${err}`); reject(err); });
+		})
 	},
 
 	removeIgnoreChannel: function(serverId, channelId) {

--- a/lib/database-helper.js
+++ b/lib/database-helper.js
@@ -146,9 +146,35 @@ const helper = {
 						.then(_ => conn.release())
 						.catch(err => console.error(`[GPR1] ${err}`));
 				})
-				.catch(err => { console.error(`[GPR2] ${err}`); reject(err) });
+				.catch(err => { console.error(`[GPR2] ${err}`); reject(err); });
 		})
 	},
+
+	getIgnoreChannels: function(serverId) {
+		return new Promise((resolve, reject) => {
+			pool.getConnection()
+				.then(conn => {
+					conn.query(`SELECT Value FROM Config WHERE Property = 'IgnoreChannel' AND Server = ?`, [serverId])
+						.then(rows => {
+							if (rows.length > 0) {
+								// filter out additional added by mariadb
+								let filteredRows = [];
+								rows.forEach(function(val) { filteredRows.push(val); });
+								resolve(filteredRows)
+							} else {
+								resolve([]);
+							}
+						})
+						.then(() => conn.release())
+						.catch(err => {
+							console.error(`[GIC] ${err}`);
+							reject(err);
+							conn.release();
+						});
+				})
+				.catch(err => { console.error(`[GIC] ${err}`); reject(err); });
+		})
+	}
 
 	/**
 	 * Punishes a specific user by giving them the punish role and logging when the user was initially punished.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "discordbrawlbot",
-  "version": "1.3.0",
+  "name": "discordbot",
+  "version": "1.3.0-BETA",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "discordbrawlbot",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A discord bot for reaction-based moderation",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "nodemon app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added ability to make bot ignore commands executed in certain channels. By default, the bot won't ignore any. To manage ignored channels, new commands were added:

!ignore help - Shows a detailed help message for managing ignored channel(s)
!ignore add <channel> - Adds a channel to the bot's ignore list 
!ignore <del|delete|rem|remove> <channel> - Removes a channel from the bot's ignore list
!ignore list - Lists all, if any, ignored channels for a server

Note: `<channel>` for all commands must be in the format of `<#channelId>`, which will appear as a highlighted channel in discord
